### PR TITLE
Issue 118

### DIFF
--- a/activity/page.php
+++ b/activity/page.php
@@ -356,8 +356,12 @@ class mobile_activity_page extends mobile_activity {
 		global $MEDIA;
 		
 		//$regex = '((\[\[[[:space:]]?media[[:space:]]?object=[\"|\'](?P<mediaobject>[\{\}\'\"\:0-9\._\-/,[:space:]\w\W]*)[[:space:]]?[\"|\']\]\]))';
-		$regex = '((\[\[[[:space:]]?media[[:space:]]?object=[\"|\'](?P<mediaobject>[\{\}\'\"\:a-zA-Z0-9\._\-/,[:space:]]*)[[:space:]]?[\"|\']\]\]))';
+		//$regex = '((\[\[[[:space:]]?media[[:space:]]?object=[\"|\'](?P<mediaobject>[\{\}\'\"\:a-zA-Z0-9\._\-/,[:space:]]*)[[:space:]]?[\"|\']\]\]))';
 		
+		//This is the regex for detecting any number of spaces or <br> tags (in any of its forms) 
+		$space_or_br_regex = '([[:space:]]|\<br\/?[[:space:]]*\>)*';
+		$regex = '((\[\[' . $space_or_br_regex . 'media' . $space_or_br_regex . 'object=[\"|\'](?P<mediaobject>[\{\}\'\"\:a-zA-Z0-9\._\-\/,[:space:]]*)([[:space:]]|\<br\/?[[:space:]]*\>)*[\"|\']' . $space_or_br_regex . '\]\]))';
+
 		preg_match_all($regex,$content,$media_tmp, PREG_OFFSET_CAPTURE);
 		
 		if(!isset($media_tmp['mediaobject']) || count($media_tmp['mediaobject']) == 0){


### PR DESCRIPTION
Solves #118 
The problem was that when inserting a \n in the content, it gets converted to a `<br>` tag. Now the regex takes that into account and matches the shortcode even if there is some `<br>` tag (in any of its forms: `<br>`, `<br/>`, `<br >`, `<br />`, etc) in between.