### PR TITLE
Issue 136

### DIFF
--- a/activity/quiz.php
+++ b/activity/quiz.php
@@ -57,8 +57,6 @@ class mobile_activity_quiz extends mobile_activity {
 	}
 	
 	function process(){
-		global $DB,$CFG,$USER,$QUIZ_CACHE;
-		$push_to_server = ($CFG->block_oppia_mobile_export_push_quizzes == 0);
 		if ($this->export_method === 'server')
 			$this->process_pushing_to_server();
 		else

--- a/activity/quiz.php
+++ b/activity/quiz.php
@@ -14,13 +14,16 @@ class mobile_activity_quiz extends mobile_activity {
 	private $configArray = array(); // config (quiz props) array
 	private $server_connection;
 	private $quiz_media = array();
+
+	private $export_method;
 	
-	function init($server_connection, $shortname, $summary, $configArray, $courseversion){
+	function init($server_connection, $shortname, $summary, $configArray, $courseversion, $export_method){
 		$this->shortname = strip_tags($shortname);
 		$this->summary = $summary;
 		$this->configArray = $configArray;
 		$this->courseversion = $courseversion;
 		$this->server_connection = $server_connection;
+		$this->export_method = $export_method;
 	}
 	
 	function preprocess(){
@@ -56,7 +59,7 @@ class mobile_activity_quiz extends mobile_activity {
 	function process(){
 		global $DB,$CFG,$USER,$QUIZ_CACHE;
 		$push_to_server = ($CFG->block_oppia_mobile_export_push_quizzes == 0);
-		if ($push_to_server)
+		if ($this->export_method === 'server')
 			$this->process_pushing_to_server();
 		else
 			$this->process_locally();

--- a/activity/quiz.php
+++ b/activity/quiz.php
@@ -231,7 +231,7 @@ class mobile_activity_quiz extends mobile_activity {
 					}
 				}
 				
-				$questionJSON = extractLangs($q->questiontext, true, true);
+				$questionJSON = extractLangs($q->questiontext, true, true, true);
 				
 				// create question
 				$post = array('title' => $questionJSON,
@@ -427,7 +427,7 @@ class mobile_activity_quiz extends mobile_activity {
 			
 			$j = 1;
 			$responses = array();
-			$questionTitle = extractLangs($q->questiontext, true);
+			$questionTitle = extractLangs($q->questiontext, true, true, true);
 
 			// if matching question then concat the options with |
 			if(isset($q->options->subquestions)){

--- a/activity/quiz.php
+++ b/activity/quiz.php
@@ -390,7 +390,7 @@ class mobile_activity_quiz extends mobile_activity {
 				$q->qtype = 'multichoice';
 			}
 
-			$questionTitle = extractLangs($q->questiontext, true);
+			
 			$questionMaxScore = intval($q->maxmark);
 			$quizMaxScore += $questionMaxScore;
 
@@ -429,6 +429,7 @@ class mobile_activity_quiz extends mobile_activity {
 			
 			$j = 1;
 			$responses = array();
+			$questionTitle = extractLangs($q->questiontext, true);
 
 			// if matching question then concat the options with |
 			if(isset($q->options->subquestions)){

--- a/activity/quiz.php
+++ b/activity/quiz.php
@@ -363,7 +363,7 @@ class mobile_activity_quiz extends mobile_activity {
 		
 		$nameJSON = extractLangs($cm->name,true);
 		$descJSON = extractLangs($this->summary,true);
-
+		$quizJson['id'] = 0;
 		$quizJson['props'] = $props;
 		$quizJson['title'] = json_decode($nameJSON);
 		$quizJson['description'] = json_decode($descJSON);
@@ -372,7 +372,6 @@ class mobile_activity_quiz extends mobile_activity {
 		//$quiz_uri = $resp->resource_uri;
 		//$quiz_id = $resp->id;
 		$quiz_uri = 'quiz_uri';
-	
 
 		$i = 1;
 		foreach($qs as $q){
@@ -413,7 +412,7 @@ class mobile_activity_quiz extends mobile_activity {
 
 			$questionTitle = extractLangs($q->questiontext, true);
 			$questionJson["title"] = json_decode($questionTitle);
-			
+			$questionJson["id"] = 0;
 			//add feedback for matching questions
 			if($q->qtype == 'match'){
 				$q->qtype = 'matching';
@@ -493,6 +492,7 @@ class mobile_activity_quiz extends mobile_activity {
 
 					array_push($responses, array(
 						'order' => $j,
+						'id' => 0,
 						'title' => json_decode(extractLangs($r->answer, true)),
 						'props' => $responseprops,
 						'score' => ($r->fraction * $q->maxmark)
@@ -506,6 +506,7 @@ class mobile_activity_quiz extends mobile_activity {
 
 			array_push($quizJsonQuestions, array(
 				'order' => $i,
+				'id' => 0,
 				'question' => $questionJson));
 			$i++;
 		}
@@ -514,7 +515,7 @@ class mobile_activity_quiz extends mobile_activity {
 		echo '<pre>'.json_encode($quizJson, JSON_PRETTY_PRINT).'</pre>';
 		// get the final quiz object
 		//$quiz = $mQH->exec('quiz/'.$quiz_id, array(),'get');
-		$this->content = json_encode($quiz);
+		$this->content = json_encode($quizJson);
 	}
 	
 	function export2print(){

--- a/activity/quiz.php
+++ b/activity/quiz.php
@@ -17,7 +17,7 @@ class mobile_activity_quiz extends mobile_activity {
 
 	private $export_method;
 	
-	function init($server_connection, $shortname, $summary, $configArray, $courseversion, $export_method){
+	function init($server_connection, $shortname, $summary, $configArray, $courseversion, $export_method='server'){
 		$this->shortname = strip_tags($shortname);
 		$this->summary = $summary;
 		$this->configArray = $configArray;

--- a/export2.php
+++ b/export2.php
@@ -217,7 +217,7 @@ foreach ($sectionmods as $modnumber) {
 								'passthreshold'=>$passthreshold,
 								'availability'=>$availability,
 								'maxattempts'=>$maxattempts);
-		$quiz->init($server_connection, $course->shortname,"Pre-test",$configArray,$versionid);
+		$quiz->init($server_connection,$course->shortname,"Pre-test",$configArray,$versionid,$QUIZ_EXPORT_METHOD);
 		$quiz->courseroot = $course_root;
 		$quiz->id = $mod->id;
 		$quiz->section = 0;

--- a/export2.php
+++ b/export2.php
@@ -61,7 +61,7 @@ $MEDIA = array();
 $DEFAULT_LANG = "en";
 $advice = array();
 
-$QUIZ_EXPORT_MINVERSION = 9;
+$QUIZ_EXPORT_MINVERSION = 10;
 $QUIZ_EXPORT_METHOD = 'server';
 
 $server_connection = $DB->get_record('block_oppia_mobile_server', array('moodleuserid'=>$USER->id,'id'=>$server));
@@ -374,7 +374,7 @@ foreach($sections as $sect) {
 									'availability'=>$availability,
 									'maxattempts'=>$maxattempts);
 				
-				$quiz->init($server_connection, $course->shortname,$sect->summary,$configArray,$versionid);
+				$quiz->init($server_connection, $course->shortname,$sect->summary,$configArray,$versionid,$QUIZ_EXPORT_METHOD);
 				$quiz->courseroot = $course_root;
 				$quiz->id = $mod->id;
 				$quiz->section = $sect_orderno;

--- a/export2.php
+++ b/export2.php
@@ -77,19 +77,6 @@ if ($server == "default"){
 	$server_connection->apikey = $CFG->block_oppia_mobile_export_default_api_key;
 }
 
-$apiHelper = new QuizHelper();
-$apiHelper->init($server_connection);
-$server_info = $apiHelper->exec('server', array(),'get', false, false);
-if ($server_info && $server_info->version ){
-	$v_regex = '/^v([0-9])+\.([0-9]+)\.([0-9]+)$/';
-	preg_match($v_regex, $server_info->version, $version_nums);
-	if (count($version_nums)>0 && (
-		($version_nums[1] > 0) || //major version check (>0.x.x)
-		($version_nums[2] >= $QUIZ_EXPORT_MINVERSION) //minor version check (>=0.10.x)
-	))
-		$QUIZ_EXPORT_METHOD = 'local';
-}
-
 //make course dir etc for output
 deleteDir("output/".$USER->id."/temp");
 deleteDir("output/".$USER->id);
@@ -168,6 +155,24 @@ if(is_array($summary) && count($summary)>0){
 	$meta->appendChild($temp);
 }
 
+$apiHelper = new QuizHelper();
+$apiHelper->init($server_connection);
+$server_info = $apiHelper->exec('server', array(),'get', false, false);
+echo '<p>';
+if ($server_info && $server_info->version ){
+	echo '<strong>Current server version:</strong> '.$server_info->version.'<br/>';
+	$v_regex = '/^v([0-9])+\.([0-9]+)\.([0-9]+)$/';
+	preg_match($v_regex, $server_info->version, $version_nums);
+	if (count($version_nums)>0 && (
+		($version_nums[1] > 0) || //major version check (>0.x.x)
+		($version_nums[2] >= $QUIZ_EXPORT_MINVERSION) //minor version check (>=0.10.x)
+	))
+		$QUIZ_EXPORT_METHOD = 'local';
+}
+else{
+	echo '<span style="color:red;">Unable to get server info (is it correctly configured and running?)</span><br/>';
+}
+echo '<strong>Quiz export method:</strong> '.$QUIZ_EXPORT_METHOD.'</p>';
 
 /*-------Get course info pages/about etc----------------------*/
 $thissection = $sections[0];

--- a/lang/en/block_oppia_mobile_export.php
+++ b/lang/en/block_oppia_mobile_export.php
@@ -170,3 +170,7 @@ $string['publish_message_401'] = 'Unauthorized. Either you entered an incorrect 
 $string['publish_message_405'] = 'Invalid HTTP request type - this probably needs a programmer to look into. Your course has not been published.';
 $string['publish_message_500'] = 'A server error occured during publishing. This could be a permissions issue, please refer to you OppiaMobile server administrator. Your course has not been published.';
 $string['publish_text'] = 'To publish your course directly on OppiaMobile ({$a}), please complete your OppiaMobile server login details below.<br/>Check with your OppiaMobile administrator if you are unsure whether you have permissions to publish on the server';
+
+$string['settings_avoid_push_quizzes'] = 'Don\'t push quizzes info to the Oppia server in the export process';
+$string['settings_avoid_push_quizzes_info'] = 'Avoid pushing quizzes info to the Oppia server in the export process. If enabled, be sure that the Oppia server is capable of processing the full course including quizzes.';
+

--- a/lib.php
+++ b/lib.php
@@ -2,6 +2,7 @@
 
 const regex_forbidden_dir_chars = '([\\/?%*:|"<>\.[:space:]]+)';
 const regex_forbidden_tag_chars = '([^a-zA-z0-9,\_]+)';
+const basic_html_tags = '<strong><b><i><em>';
 
 function deleteDir($dirPath) {
 	if (! is_dir($dirPath)) {
@@ -67,7 +68,7 @@ function get_oppiaservers(){
 	return $servers;
 }
 
-function extractLangs($content, $asJSON = false, $strip_tags = false){
+function extractLangs($content, $asJSON = false, $strip_tags = false, $keep_basic_tags = false){
 	global $MOBILE_LANGS, $CURRENT_LANG, $DEFAULT_LANG;
 	preg_match_all('((lang=[\'|\"](?P<langs>[\w\-]*)[\'|\"]))',$content,$langs_tmp, PREG_OFFSET_CAPTURE);
 	$tempLangs = array();
@@ -81,7 +82,10 @@ function extractLangs($content, $asJSON = false, $strip_tags = false){
 		return $content;
 	} else {
 		$json = new stdClass;
-		$json->{$DEFAULT_LANG} = trim(strip_tags($content));
+		if ($keep_basic_tags)
+			$json->{$DEFAULT_LANG} = trim(strip_tags($content, basic_html_tags));
+		else
+			$json->{$DEFAULT_LANG} = trim(strip_tags($content));
 		return json_encode($json);
 	}
 
@@ -89,7 +93,10 @@ function extractLangs($content, $asJSON = false, $strip_tags = false){
 	foreach($tempLangs as $k=>$v){
 		$CURRENT_LANG = $k;
 		if ($strip_tags){
-			$tempLangs[$k] = trim(strip_tags($filter->filter($content)));
+			if ($keep_basic_tags)
+				$tempLangs[$k] = trim(strip_tags($filter->filter($content), basic_html_tags));
+			else
+				$tempLangs[$k] = trim(strip_tags($filter->filter($content)));
 		} else {
 			$tempLangs[$k] = trim($filter->filter($content));
 		}
@@ -100,6 +107,7 @@ function extractLangs($content, $asJSON = false, $strip_tags = false){
 	foreach($tempLangsRev as $k=>$v){
 		$MOBILE_LANGS[$k] = true;
 	}
+
 	if ($asJSON){
 		return json_encode($tempLangsRev);
 	} else {

--- a/oppia_api_helper.php
+++ b/oppia_api_helper.php
@@ -10,14 +10,14 @@ class QuizHelper{
 		curl_setopt($this->curl, CURLOPT_RETURNTRANSFER, 1 );
 	}
 	
-	function exec($object, $data_array, $type='post'){
+	function exec($object, $data_array, $type='post', $api_path=true, $print_error_msg=true){
 		
 		$json = json_encode($data_array);
 		// Check if the url already has trailing '/' or not
 		if (substr($this->connection->url, -strlen('/'))==='/'){ 
-			$temp_url = $this->connection->url."api/v1/".$object."/";
+			$temp_url = $this->connection->url.($api_path ? "api/v1/" : "").$object."/";
 		} else {
-			$temp_url = $this->connection->url."/api/v1/".$object."/";
+			$temp_url = $this->connection->url."/".($api_path ? "api/v1/" : "").$object."/";
 		}
 		$temp_url .= "?format=json";
 		$temp_url .= "&username=".$this->connection->username;
@@ -33,7 +33,7 @@ class QuizHelper{
 		$data = curl_exec($this->curl);
 		$json = json_decode($data);
 		$http_status = curl_getinfo($this->curl, CURLINFO_HTTP_CODE);
-		if ($http_status != 200 && $http_status != 201){
+		if ($http_status != 200 && $http_status != 201 && $print_error_msg){
 			echo "<p style='color:red'>".get_string('error_creating_quiz','block_oppia_mobile_export')." ( status code: " . $http_status . ")</p>";
 		}
 		return $json;

--- a/settings.php
+++ b/settings.php
@@ -23,8 +23,5 @@ if ($ADMIN->fulltree) {
 	
 	$settings->add(new admin_setting_configcheckbox('block_oppia_mobile_export_debug', get_string('debug', 'block_oppia_mobile_export'),
 			get_string('debug_info', 'block_oppia_mobile_export'), 1));
-
-	$settings->add(new admin_setting_configcheckbox('block_oppia_mobile_export_push_quizzes', get_string('settings_avoid_push_quizzes', 'block_oppia_mobile_export'),
-			get_string('settings_avoid_push_quizzes_info', 'block_oppia_mobile_export'), 0));
 }
 ?>

--- a/settings.php
+++ b/settings.php
@@ -23,5 +23,8 @@ if ($ADMIN->fulltree) {
 	
 	$settings->add(new admin_setting_configcheckbox('block_oppia_mobile_export_debug', get_string('debug', 'block_oppia_mobile_export'),
 			get_string('debug_info', 'block_oppia_mobile_export'), 1));
+
+	$settings->add(new admin_setting_configcheckbox('block_oppia_mobile_export_push_quizzes', get_string('settings_avoid_push_quizzes', 'block_oppia_mobile_export'),
+			get_string('settings_avoid_push_quizzes_info', 'block_oppia_mobile_export'), 0));
 }
 ?>


### PR DESCRIPTION
Solves #136
Added an additional parameter to `extractLangs()` to avoid stripping some tags, currently using it only for question titles.

It merges the PR#156 to add the functionality to both the server and local export methods
Tags that are kept: `<b>`,`<strong>`,`<i>` and `<em>`