### PR TITLE
Wrong PATH attribute in some XMLDB install.xml files

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="blocks/oppia_mobile_export" VERSION="2013111401" COMMENT="XMLDB file for Moodle block/oppia_mobile_export">
+<XMLDB PATH="blocks/oppia_mobile_export/db" VERSION="2013111401" COMMENT="XMLDB file for Moodle block/oppia_mobile_export/db">
   <TABLES>
     <TABLE NAME="block_oppia_mobile_config" COMMENT="">
       <FIELDS>

--- a/settings.php
+++ b/settings.php
@@ -18,8 +18,8 @@ if ($ADMIN->fulltree) {
 	$settings->add(new admin_setting_configtext('block_oppia_mobile_export_thumb_bg_g', get_string('thumb_bg_g', 'block_oppia_mobile_export'),'', 51, PARAM_INT));
 	$settings->add(new admin_setting_configtext('block_oppia_mobile_export_thumb_bg_b', get_string('thumb_bg_b', 'block_oppia_mobile_export'),'', 51, PARAM_INT));
 	
-	$settings->add(new admin_setting_configtext('block_oppia_mobile_export_course_icon_width', get_string('course_icon_width', 'block_oppia_mobile_export'),'', 60, PARAM_INT));
-	$settings->add(new admin_setting_configtext('block_oppia_mobile_export_course_icon_height', get_string('course_icon_height', 'block_oppia_mobile_export'),'', 60, PARAM_INT));
+	$settings->add(new admin_setting_configtext('block_oppia_mobile_export_course_icon_width', get_string('course_icon_width', 'block_oppia_mobile_export'),'', 500, PARAM_INT));
+	$settings->add(new admin_setting_configtext('block_oppia_mobile_export_course_icon_height', get_string('course_icon_height', 'block_oppia_mobile_export'),'', 500, PARAM_INT));
 	
 	$settings->add(new admin_setting_configcheckbox('block_oppia_mobile_export_thumb_crop', get_string('thumbcrop', 'block_oppia_mobile_export'),get_string('thumbcrop_info', 'block_oppia_mobile_export'),1));
 	


### PR DESCRIPTION
Error in newer versions of moodle
Debug info: Errors found in XMLDB file: PATH attribute does not match file directory: blocks/oppia_mobile_export/db Error code: ddlxmlfileerror